### PR TITLE
[Feat] Add Weather_ELT DAG, raw to analytics DAG

### DIFF
--- a/dags/ELT_weather.py
+++ b/dags/ELT_weather.py
@@ -65,7 +65,7 @@ with DAG(
     start_date=datetime(2024, 6, 1, 00, 10),
     schedule=timedelta(days=1),
     max_active_runs=1,
-    catchup=False,
+    catchup=True,
     default_args={
         'retries': 1,
         'retry_delay': timedelta(minutes=2),

--- a/dags/ELT_weather.py
+++ b/dags/ELT_weather.py
@@ -47,7 +47,7 @@ def sum_csv_transform_csv_to_parquet():
                 records.append([int(S), TM, float(L_VIS), float(L_RVR), float(CH_MIN), float(TA), float(HM), float(PA), float(RN), float(WS02), float(WS02_MAX), float(WS02_MIN), float(WS10), float(WS10_MAX), float(WS10_MIN)])
             
     df = pd.DataFrame(records, columns=['S', 'TM', 'L_VIS', 'L_RVR', 'CH_MIN', 'TA', 'HM', 'PA', 'RN', 'WS02', 'WS02_MAX', 'WS02_MIN', 'WS10', 'WS10_MAX', 'WS10_MIN'])
-    table = pa.Table.from_pandas(df)
+    table = pa.Table.from_pandas(df, preserve_index = False)
     pq.write_table(table, 'tmp/airport_weather_infor.parquet')
 
 
@@ -62,7 +62,7 @@ def delete_csv_files(local_dir):
 
 with DAG(
     dag_id='Weather_ELT',
-    start_date=datetime(2024, 6, 1, 00, 10),
+    start_date=datetime(2024, 6, 1),
     schedule=timedelta(days=1),
     max_active_runs=1,
     catchup=True,

--- a/dags/ELT_weather.py
+++ b/dags/ELT_weather.py
@@ -1,0 +1,106 @@
+from airflow import DAG
+from airflow.models import Variable
+from airflow.providers.google.cloud.transfers.local_to_gcs import LocalFilesystemToGCSOperator
+from airflow.providers.google.cloud.transfers.gcs_to_bigquery import GCSToBigQueryOperator
+from airflow.contrib.hooks.gcs_hook import GCSHook
+from airflow.decorators import task
+
+from datetime import datetime
+from datetime import timedelta
+from plugins import slack
+
+import os
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+
+@task
+def download_gcs_bucket(gcp_conn_id, bucket_name, folder_path, local_dir):
+
+    gcs_hook = GCSHook(gcp_conn_id=gcp_conn_id)
+    
+    # 로컬 디렉토리 생성
+    if not os.path.exists(local_dir):
+        os.makedirs(local_dir)
+    
+    # GCS 버킷 폴더의 객체(파일) 목록 가져오기
+    objects = gcs_hook.list(bucket_name=bucket_name, prefix=folder_path)
+    
+    # 각 객체(파일) 다운로드
+    for obj in objects:
+        local_path = os.path.join(local_dir, os.path.basename(obj))
+        gcs_hook.download(bucket_name=bucket_name, object_name=obj, filename=local_path)
+
+
+@task
+def sum_csv_transform_csv_to_parquet():
+    csv_files = [f for f in os.listdir('tmp/GCS') if f.endswith('.csv')]
+
+    records = []
+    for csv_file in csv_files:
+        file_path = os.path.join('tmp/GCS', csv_file)
+        line = (open(file_path, 'r').read()).strip().split("\n") 
+        for l in line:
+            (NUMBERING1, NUMBERING2, S, TM, L_VIS, R_VIS, L_RVR, R_RVR, CH_MIN, TA, TD, HM, PS, PA, RN, B1, B2, WD02, WD02_MAX, WD02_MIN, WS02, WS02_MAX, WS02_MIN, WD10, WD10_MAX, WD10_MIN, WS10, WS10_MAX, WS10_MIN) = l.split(",")
+            if NUMBERING1 != '\ufeff':
+                TM = datetime.strptime(TM, '%Y%m%d%H%M')
+                records.append([int(S), TM, float(L_VIS), float(L_RVR), float(CH_MIN), float(TA), float(HM), float(PA), float(RN), float(WS02), float(WS02_MAX), float(WS02_MIN), float(WS10), float(WS10_MAX), float(WS10_MIN)])
+            
+    df = pd.DataFrame(records, columns=['S', 'TM', 'L_VIS', 'L_RVR', 'CH_MIN', 'TA', 'HM', 'PA', 'RN', 'WS02', 'WS02_MAX', 'WS02_MIN', 'WS10', 'WS10_MAX', 'WS10_MIN'])
+    table = pa.Table.from_pandas(df)
+    pq.write_table(table, 'tmp/airport_weather_infor.parquet')
+
+
+@task
+def delete_csv_files(local_dir):
+    csv_files = [f for f in os.listdir(local_dir) if f.endswith('.csv')]
+
+    for csv_file in csv_files:
+        file_path = os.path.join(local_dir, csv_file)
+        os.remove(file_path)
+
+
+with DAG(
+    dag_id='Weather_ELT',
+    start_date=datetime(2024, 6, 1, 00, 10),
+    schedule=timedelta(days=1),
+    max_active_runs=1,
+    catchup=False,
+    default_args={
+        'retries': 1,
+        'retry_delay': timedelta(minutes=2),
+        'on_failure_callback': slack.on_failure_callback,
+    }
+) as dag:
+
+
+    upload_gcs_stage = LocalFilesystemToGCSOperator(
+    task_id='upload_to_gcs_stage', 
+    src='tmp/airport_weather_infor.parquet',
+    dst='source/weather/{{ prev_execution_date.in_timezone("Asia/Seoul").strftime("%Y/%m/%d") }}/weather_infor_{{ prev_execution_date.in_timezone("Asia/Seoul").strftime("%Y%m%d") }}.parquet', 
+    bucket='pdc3project-stage-layer-bucket',
+    gcp_conn_id='google_cloud_GCS',
+    dag=dag 
+    )
+
+
+    upload_to_bigquery = GCSToBigQueryOperator(
+    task_id='upload_to_bq',
+    bucket='pdc3project-stage-layer-bucket',
+    source_objects=['source/weather/{{ prev_execution_date.in_timezone("Asia/Seoul").strftime("%Y/%m/%d") }}/weather_infor_{{ prev_execution_date.in_timezone("Asia/Seoul").strftime("%Y%m%d") }}.parquet'],
+    destination_project_dataset_table='pdc3project.raw_data.weather_infor',
+    source_format='PARQUET',
+    autodetect=True,
+    write_disposition='WRITE_APPEND',
+    gcp_conn_id='google_cloud_bigquery',
+    dag=dag
+    )
+    
+    gcp_conn_id = 'google_cloud_GCS'
+    bucket_name = 'pdc3project-landing-zone-bucket'
+    folder_path = 'source/weather/{{ prev_execution_date.in_timezone("Asia/Seoul").strftime("%Y/%m/%d") }}'
+    local_dir = 'tmp/GCS'
+
+
+    download_gcs_bucket(gcp_conn_id, bucket_name, folder_path, local_dir) >> sum_csv_transform_csv_to_parquet() >> upload_gcs_stage >> delete_csv_files(local_dir) >> upload_to_bigquery

--- a/dags/ELT_weather.py
+++ b/dags/ELT_weather.py
@@ -62,7 +62,7 @@ def delete_csv_files(local_dir):
 
 with DAG(
     dag_id='Weather_ELT',
-    start_date=datetime(2024, 6, 1),
+    start_date=datetime(2024, 6, 1, 00, 20),
     schedule=timedelta(days=1),
     max_active_runs=1,
     catchup=True,

--- a/dags/ELT_weather.py
+++ b/dags/ELT_weather.py
@@ -41,10 +41,11 @@ def sum_csv_transform_csv_to_parquet():
     for csv_file in csv_files:
         file_path = os.path.join('tmp/GCS', csv_file)
         line = (open(file_path, 'r').read()).strip().split("\n") 
-        for l in line[1:]:
+        for l in line:
             (NUMBERING1, NUMBERING2, S, TM, L_VIS, R_VIS, L_RVR, R_RVR, CH_MIN, TA, TD, HM, PS, PA, RN, B1, B2, WD02, WD02_MAX, WD02_MIN, WS02, WS02_MAX, WS02_MIN, WD10, WD10_MAX, WD10_MIN, WS10, WS10_MAX, WS10_MIN) = l.split(",")
-            TM = datetime.strptime(TM, '%Y%m%d%H%M')
-            records.append([int(S), TM, float(L_VIS), float(L_RVR), float(CH_MIN), float(TA), float(HM), float(PA), float(RN), float(WS02), float(WS02_MAX), float(WS02_MIN), float(WS10), float(WS10_MAX), float(WS10_MIN)])
+            if NUMBERING1 != '\ufeff':
+                TM = datetime.strptime(TM, '%Y%m%d%H%M')
+                records.append([int(S), TM, float(L_VIS), float(L_RVR), float(CH_MIN), float(TA), float(HM), float(PA), float(RN), float(WS02), float(WS02_MAX), float(WS02_MIN), float(WS10), float(WS10_MAX), float(WS10_MIN)])
             
     df = pd.DataFrame(records, columns=['S', 'TM', 'L_VIS', 'L_RVR', 'CH_MIN', 'TA', 'HM', 'PA', 'RN', 'WS02', 'WS02_MAX', 'WS02_MIN', 'WS10', 'WS10_MAX', 'WS10_MIN'])
     table = pa.Table.from_pandas(df)

--- a/dags/ELT_weather.py
+++ b/dags/ELT_weather.py
@@ -41,12 +41,11 @@ def sum_csv_transform_csv_to_parquet():
     for csv_file in csv_files:
         file_path = os.path.join('tmp/GCS', csv_file)
         line = (open(file_path, 'r').read()).strip().split("\n") 
-        for l in line:
+        for l in line[1:]:
             (NUMBERING1, NUMBERING2, S, TM, L_VIS, R_VIS, L_RVR, R_RVR, CH_MIN, TA, TD, HM, PS, PA, RN, B1, B2, WD02, WD02_MAX, WD02_MIN, WS02, WS02_MAX, WS02_MIN, WD10, WD10_MAX, WD10_MIN, WS10, WS10_MAX, WS10_MIN) = l.split(",")
-            if NUMBERING1 != '\ufeff':
-                TM = datetime.strptime(TM, '%Y%m%d%H%M')
-                records.append([int(S), TM, float(L_VIS), float(L_RVR), float(CH_MIN), float(TA), float(HM), float(PA), float(RN), float(WS02), float(WS02_MAX), float(WS02_MIN), float(WS10), float(WS10_MAX), float(WS10_MIN)])
-            
+            TM = datetime.strptime(TM, '%Y%m%d%H%M')
+            records.append([int(S), TM, float(L_VIS), float(L_RVR), float(CH_MIN), float(TA), float(HM), float(PA), float(RN), float(WS02), float(WS02_MAX), float(WS02_MIN), float(WS10), float(WS10_MAX), float(WS10_MIN)])
+            print(TM)
     df = pd.DataFrame(records, columns=['S', 'TM', 'L_VIS', 'L_RVR', 'CH_MIN', 'TA', 'HM', 'PA', 'RN', 'WS02', 'WS02_MAX', 'WS02_MIN', 'WS10', 'WS10_MAX', 'WS10_MIN'])
     table = pa.Table.from_pandas(df)
     pq.write_table(table, 'tmp/airport_weather_infor.parquet')
@@ -70,7 +69,7 @@ with DAG(
     default_args={
         'retries': 1,
         'retry_delay': timedelta(minutes=2),
-        'on_failure_callback': slack.on_failure_callback,
+        # 'on_failure_callback': slack.on_failure_callback,
     }
 ) as dag:
 

--- a/dags/ELT_weather.py
+++ b/dags/ELT_weather.py
@@ -77,7 +77,7 @@ with DAG(
     upload_gcs_stage = LocalFilesystemToGCSOperator(
     task_id='upload_to_gcs_stage', 
     src='tmp/airport_weather_infor.parquet',
-    dst='source/weather/{{ prev_execution_date.in_timezone("Asia/Seoul").strftime("%Y/%m/%d") }}/weather_infor_{{ prev_execution_date.in_timezone("Asia/Seoul").strftime("%Y%m%d") }}.parquet', 
+    dst='source/weather/{{ execution_date.in_timezone("Asia/Seoul").strftime("%Y/%m/%d") }}/weather_infor_{{ execution_date.in_timezone("Asia/Seoul").strftime("%Y%m%d") }}.parquet', 
     bucket='pdc3project-stage-layer-bucket',
     gcp_conn_id='google_cloud_GCS',
     dag=dag 
@@ -87,7 +87,7 @@ with DAG(
     upload_to_bigquery = GCSToBigQueryOperator(
     task_id='upload_to_bq',
     bucket='pdc3project-stage-layer-bucket',
-    source_objects=['source/weather/{{ prev_execution_date.in_timezone("Asia/Seoul").strftime("%Y/%m/%d") }}/weather_infor_{{ prev_execution_date.in_timezone("Asia/Seoul").strftime("%Y%m%d") }}.parquet'],
+    source_objects=['source/weather/{{ execution_date.in_timezone("Asia/Seoul").strftime("%Y/%m/%d") }}/weather_infor_{{ execution_date.in_timezone("Asia/Seoul").strftime("%Y%m%d") }}.parquet'],
     destination_project_dataset_table='pdc3project.raw_data.weather_infor',
     source_format='PARQUET',
     autodetect=True,
@@ -98,7 +98,7 @@ with DAG(
     
     gcp_conn_id = 'google_cloud_GCS'
     bucket_name = 'pdc3project-landing-zone-bucket'
-    folder_path = 'source/weather/{{ prev_execution_date.in_timezone("Asia/Seoul").strftime("%Y/%m/%d") }}'
+    folder_path = 'source/weather/{{ execution_date.in_timezone("Asia/Seoul").strftime("%Y/%m/%d") }}'
     local_dir = 'tmp/GCS'
 
 

--- a/dags/ELT_weather.py
+++ b/dags/ELT_weather.py
@@ -41,11 +41,10 @@ def sum_csv_transform_csv_to_parquet():
     for csv_file in csv_files:
         file_path = os.path.join('tmp/GCS', csv_file)
         line = (open(file_path, 'r').read()).strip().split("\n") 
-        for l in line:
+        for l in line[1:]:
             (NUMBERING1, NUMBERING2, S, TM, L_VIS, R_VIS, L_RVR, R_RVR, CH_MIN, TA, TD, HM, PS, PA, RN, B1, B2, WD02, WD02_MAX, WD02_MIN, WS02, WS02_MAX, WS02_MIN, WD10, WD10_MAX, WD10_MIN, WS10, WS10_MAX, WS10_MIN) = l.split(",")
-            if NUMBERING1 != '\ufeff':
-                TM = datetime.strptime(TM, '%Y%m%d%H%M')
-                records.append([int(S), TM, float(L_VIS), float(L_RVR), float(CH_MIN), float(TA), float(HM), float(PA), float(RN), float(WS02), float(WS02_MAX), float(WS02_MIN), float(WS10), float(WS10_MAX), float(WS10_MIN)])
+            TM = datetime.strptime(TM, '%Y%m%d%H%M')
+            records.append([int(S), TM, float(L_VIS), float(L_RVR), float(CH_MIN), float(TA), float(HM), float(PA), float(RN), float(WS02), float(WS02_MAX), float(WS02_MIN), float(WS10), float(WS10_MAX), float(WS10_MIN)])
             
     df = pd.DataFrame(records, columns=['S', 'TM', 'L_VIS', 'L_RVR', 'CH_MIN', 'TA', 'HM', 'PA', 'RN', 'WS02', 'WS02_MAX', 'WS02_MIN', 'WS10', 'WS10_MAX', 'WS10_MIN'])
     table = pa.Table.from_pandas(df)

--- a/dags/ELT_weather.py
+++ b/dags/ELT_weather.py
@@ -78,7 +78,7 @@ with DAG(
     upload_gcs_stage = LocalFilesystemToGCSOperator(
     task_id='upload_to_gcs_stage', 
     src='tmp/airport_weather_infor.parquet',
-    dst='source/weather/{{ prev_execution_date.in_timezone("Asia/Seoul").strftime("%Y/%m/%d") }}/weather_infor_{{ prev_execution_date.in_timezone("Asia/Seoul").strftime("%Y%m%d") }}.parquet', 
+    dst='source/weather/{{ execution_date.in_timezone("Asia/Seoul").strftime("%Y/%m/%d") }}/weather_infor_{{ execution_date.in_timezone("Asia/Seoul").strftime("%Y%m%d") }}.parquet', 
     bucket='pdc3project-stage-layer-bucket',
     gcp_conn_id='google_cloud_GCS',
     dag=dag 
@@ -88,7 +88,7 @@ with DAG(
     upload_to_bigquery = GCSToBigQueryOperator(
     task_id='upload_to_bq',
     bucket='pdc3project-stage-layer-bucket',
-    source_objects=['source/weather/{{ prev_execution_date.in_timezone("Asia/Seoul").strftime("%Y/%m/%d") }}/weather_infor_{{ prev_execution_date.in_timezone("Asia/Seoul").strftime("%Y%m%d") }}.parquet'],
+    source_objects=['source/weather/{{ execution_date.in_timezone("Asia/Seoul").strftime("%Y/%m/%d") }}/weather_infor_{{ execution_date.in_timezone("Asia/Seoul").strftime("%Y%m%d") }}.parquet'],
     destination_project_dataset_table='pdc3project.raw_data.weather_infor',
     source_format='PARQUET',
     autodetect=True,
@@ -99,7 +99,7 @@ with DAG(
     
     gcp_conn_id = 'google_cloud_GCS'
     bucket_name = 'pdc3project-landing-zone-bucket'
-    folder_path = 'source/weather/{{ prev_execution_date.in_timezone("Asia/Seoul").strftime("%Y/%m/%d") }}'
+    folder_path = 'source/weather/{{ execution_date.in_timezone("Asia/Seoul").strftime("%Y/%m/%d") }}'
     local_dir = 'tmp/GCS'
 
 

--- a/dags/Weather_ETL.py
+++ b/dags/Weather_ETL.py
@@ -62,7 +62,7 @@ with DAG(
     start_date=datetime(2024, 5, 31, 16, 4),  # 이 시간에서 8시간 55분을 더하면 202406011259 -> 202406011200 ~ 202406011259 데이터 가져오도록 유도
     schedule=timedelta(minutes=60),  
     max_active_runs=1,
-    catchup=False,
+    catchup=True,
     default_args={
         'retries': 1,
         'retry_delay': timedelta(minutes=3),

--- a/dags/Weather_ETL.py
+++ b/dags/Weather_ETL.py
@@ -58,7 +58,7 @@ def transform(text):
 
 
 with DAG(
-    dag_id='update_weather_infor',
+    dag_id='Weather_ETL',
     start_date=datetime(2024, 5, 31, 16, 4),  # 이 시간에서 8시간 55분을 더하면 202406011259 -> 202406011200 ~ 202406011259 데이터 가져오도록 유도
     schedule=timedelta(minutes=60),  
     max_active_runs=1,

--- a/dags/raw_to_analytics_weather.py
+++ b/dags/raw_to_analytics_weather.py
@@ -22,14 +22,8 @@ with DAG(
     query = """
         DROP TABLE IF EXISTS analytics.up_30m_with_weather;
         CREATE TABLE analytics.up_30m_with_weather AS 
-        SELECT DISTINCT(SUBSTRING(wi.TM, 5, 8)) AS STD, fda.BOARDING_KOR AS DEPARTURE_AP, (fda.ETD-fda.STD) AS DELAY_TIME, wi.WS10/10 AS WS10, wi.HM, wi.PA/10 AS PA, wi.TA/10 AS TA, wi.RN/10 AS RN 
-        FROM (
-        SELECT *, '서울/김포' AS target_airport FROM `pdc3project.raw_data.flight_data_GIMPO`
-            UNION ALL
-        SELECT *, '인천' AS target_airport FROM `pdc3project.raw_data.flight_data_INCHEON`
-            UNION ALL
-        SELECT *, '제주' AS target_airport FROM `pdc3project.raw_data.flight_data_JEJU`
-        ) AS fda
+        SELECT DISTINCT(DATETIME(SUBSTRING(wi.TM, 1, 4) || '-' || SUBSTRING(wi.TM, 5, 2) || '-' || SUBSTRING(wi.TM, 7, 2) || ' ' ||  SUBSTRING(wi.TM, 9, 2) || ':' || SUBSTRING(wi.TM, 11, 2) || ':00')) AS STD, fda.BOARDING_KOR AS DEPARTURE_AP, (fda.ETD-fda.STD) AS DELAY_TIME, wi.WS10/10 AS WS10, wi.HM, wi.PA/10 AS PA, wi.TA/10 AS TA, wi.RN/10 AS RN 
+        FROM `pdc3project.raw_data.flight_data` AS fda
         JOIN (
             SELECT w.TM, w.WS10, w.HM, w.PA, w.TA, w.RN, wac.AIRPORT_NAME, wac.AIRPORT_CODE
             FROM `pdc3project.raw_data.weather_infor` AS w

--- a/dags/raw_to_analytics_weather.py
+++ b/dags/raw_to_analytics_weather.py
@@ -1,0 +1,59 @@
+from airflow import DAG
+from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
+from datetime import timedelta
+from datetime import datetime
+from plugins import slack
+
+
+with DAG(
+    dag_id='raw_to_analytics_weather',
+    description='ETL from raw_data to analytics in BigQuery',
+    schedule_interval='@daily',
+    start_date=datetime(2024, 6, 1, 00, 30),
+    max_active_runs=1,
+    catchup=False,
+    default_args={
+        'retries': 1,
+        'retry_delay': timedelta(minutes=2),
+        'on_failure_callback': slack.on_failure_callback,
+    }
+) as dag:
+
+    query = """
+        DROP TABLE IF EXISTS analytics.up_30m_with_weather;
+        CREATE TABLE analytics.up_30m_with_weather AS 
+        SELECT DISTINCT(SUBSTRING(wi.TM, 5, 8)) AS STD, fda.BOARDING_KOR AS DEPARTURE_AP, (fda.ETD-fda.STD) AS DELAY_TIME, wi.WS10/10 AS WS10, wi.HM, wi.PA/10 AS PA, wi.TA/10 AS TA, wi.RN/10 AS RN 
+        FROM (
+        SELECT *, '서울/김포' AS target_airport FROM `pdc3project.raw_data.flight_data_GIMPO`
+            UNION ALL
+        SELECT *, '인천' AS target_airport FROM `pdc3project.raw_data.flight_data_INCHEON`
+            UNION ALL
+        SELECT *, '제주' AS target_airport FROM `pdc3project.raw_data.flight_data_JEJU`
+        ) AS fda
+        JOIN (
+            SELECT w.TM, w.WS10, w.HM, w.PA, w.TA, w.RN, wac.AIRPORT_NAME, wac.AIRPORT_CODE
+            FROM `pdc3project.raw_data.weather_infor` AS w
+            JOIN `pdc3project.raw_data.weather_airport_conn` AS wac
+            ON w.S = wac.S
+        ) wi
+        ON LEFT(wi.AIRPORT_NAME, 2) = RIGHT(fda.BOARDING_KOR, 2)
+        AND CAST(SUBSTRING(wi.TM, 1, 4) AS INT64) = EXTRACT(YEAR FROM fda.FLIGHT_DATE)
+        AND CAST(SUBSTRING(wi.TM, 5, 2) AS INT64) = EXTRACT(MONTH FROM fda.FLIGHT_DATE)
+        AND CAST(SUBSTRING(wi.TM, 7, 2) AS INT64) = EXTRACT(DAY FROM fda.FLIGHT_DATE)
+        AND CAST(SUBSTRING(wi.TM, 9, 4) AS INT64) = fda.STD
+        WHERE (fda.ETD-fda.STD) >= 30
+        ORDER BY fda.BOARDING_KOR, DELAY_TIME DESC, STD;
+    """
+
+    raw_to_analytics = BigQueryInsertJobOperator(
+        task_id="raw_to_analytics",
+        configuration={
+            "query": {
+                "query": query,
+                "useLegacySql": False,
+            }
+        },
+        gcp_conn_id='google_cloud_bigquery',
+        dag=dag,
+    )
+


### PR DESCRIPTION
**Weather_ELT (Feat)**
- GCS landing -> transform -> GCS stage -> BigQuery raw_data 적재 DAG

GCS landing bucket에서 받아와 csv에 존재하는 데이터를 모아 transform 후 parquet으로 저장하여 GCS stage bucket에 적재.
이후 parquet을 Bigquery raw_data 테이블(weather_infor)로 생성하는 DAG

**raw_to_analytics_weather (Feat)**
- BigQuery raw_data -> transform -> BigQuery analytics 적재 DAG

BigQuery raw_data(flight_data, weather_infor, weather_airport_conn)의 테이블을 필요한 데이터만 적절히 가공하여 analytics에 테이블(up_30m_with_weather) 생성을 하는 DAG
이 때 생성된 analytics의 테이블로 지연시간별 풍속, 강수량 그래프를 그리는 데 사용됩니다.

**Weather_ETL (Fix)**
- catchup = False -> True
- start_date 변경
