### PR TITLE
[Feat] Add Parking_CJU_ELT,Parking_INT_ELT,Parking_GMP_ELT

### DIFF
--- a/dags/CJU_Parking.py
+++ b/dags/CJU_Parking.py
@@ -45,7 +45,7 @@ def parse_xml_data(xml_data):
             'airportKor': item.find('airportKor').text,
             'parkingAirportCodeName': item.find('parkingAirportCodeName').text,
             'parkingCongestion': item.find('parkingCongestion').text,
-            'parkingCongestionDegree': item.find('parkingCongestionDegree').text,
+            'parkingCongestionDegree': int(item.find('parkingCongestionDegree').text[:2]),
             'parkingOccupiedSpace': item.find('parkingOccupiedSpace').text,
             'parkingTotalSpace': item.find('parkingTotalSpace').text,
             'datetm': datetm

--- a/dags/CJU_Parking.py
+++ b/dags/CJU_Parking.py
@@ -1,5 +1,5 @@
 from airflow import DAG
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.providers.google.cloud.transfers.local_to_gcs import LocalFilesystemToGCSOperator
 from airflow.utils.dates import days_ago
 from datetime import datetime, timedelta
@@ -8,9 +8,10 @@ import pandas as pd
 import xml.etree.ElementTree as ET
 from airflow.models import Variable
 from plugins import slack
-import json
+import pytz
 
 
+# Function to fetch XML data from the API
 def fetch_xml_data(airport_code):
     url = 'http://openapi.airport.co.kr/service/rest/AirportParkingCongestion/airportParkingCongestionRT'
     parking_api_key = Variable.get('parking_api_key')
@@ -25,11 +26,13 @@ def fetch_xml_data(airport_code):
     response.raise_for_status()
     return response.text
 
+
+# Function to calculate parking congestion degree and status
+
 def calculate_date(sysGetdate, sysGettime):
     datetm = f"{sysGetdate[:4]}{sysGetdate[5:7]}{sysGetdate[8:]}{sysGettime[:2]}{sysGettime[3:5]}{sysGettime[6:]}"
     return datetm
 
-# Function to fetch parking data for a specific airport code
 def parse_xml_data(xml_data):
     root = ET.fromstring(xml_data)
     items = []
@@ -50,16 +53,53 @@ def parse_xml_data(xml_data):
     return items
 
 
-# Main function to fetch and upload data for both GMP and CJU
+# Function to upload data to Google Cloud Storage
 def update_parking_data():
-    data_cju = fetch_xml_data('CJU')
-    parsed_data_cju = parse_xml_data(data_cju)
-    df = pd.DataFrame(parsed_data_cju)
-    df.to_csv('/tmp/CJU_parking_data.csv', index=False, encoding='utf-8-sig')
+    data_gmp = fetch_xml_data('CJU')
+    parsed_data_gmp = parse_xml_data(data_gmp)
+    df = pd.DataFrame(parsed_data_gmp)
+    df.to_csv('/tmp/GMP_parking_data.csv', index=False, encoding='utf-8-sig')
     print("Domestic data fetched and saved to '/tmp/CJU_parking_data.csv'")
 
 
-# Default settings for the DAG
+# Convert UTC to KST
+def convert_to_kst(execution_date):
+    # UTC에서 한국 시간으로 변환
+    execution_date_utc = execution_date.replace(tzinfo=pytz.UTC)
+    execution_date_kst = execution_date_utc.astimezone(pytz.timezone('Asia/Seoul'))
+    return execution_date_kst.strftime('%Y-%m-%d %H:%M:%S')
+
+def set_kst_execution_date(**kwargs):
+    # Airflow의 execution_date를 가져와서 한국 시간대로 변환 후 XCom에 저장
+    execution_date = kwargs['execution_date']
+    execution_date_kst = convert_to_kst(execution_date)
+    ti = kwargs['ti']
+    ti.xcom_push(key='execution_date_kst', value=execution_date_kst)
+
+# Function to retrieve the KST execution date from XCom and format the destination path
+def get_kst_execution_date_path(**kwargs):
+    ti = kwargs['ti']
+    execution_date_kst = ti.xcom_pull(task_ids='set_kst_execution_date', key='execution_date_kst')
+    # Convert the pulled execution_date_kst string back to a datetime object
+    execution_date_kst_dt = datetime.strptime(execution_date_kst, '%Y-%m-%d %H:%M:%S')
+    formatted_day = execution_date_kst_dt.strftime("%d")
+    formatted_timestamp = execution_date_kst_dt.strftime("%Y%m%d%H%M")
+    return f'source/source_parkinglot/CJU_parking_data/2024/06/{formatted_day}/CJU_parking_data_{formatted_timestamp}.csv'
+
+def upload_to_gcs_callable(**kwargs):
+    dst_path = get_kst_execution_date_path(**kwargs)
+    # Use the path in LocalFilesystemToGCSOperator
+    LocalFilesystemToGCSOperator(
+        task_id='upload_CJU_parking_data',
+        src='/tmp/CJU_parking_data.csv',
+        dst=dst_path,
+        bucket='pdc3project-landing-zone-bucket',
+        gcp_conn_id='google_cloud_GCS',
+        dag=kwargs['dag'],
+    ).execute(kwargs)
+
+
+# Define the default_args for the DAG
 default_args = {
     'owner': 'airflow',
     'start_date': days_ago(1),
@@ -70,27 +110,31 @@ default_args = {
 
 # Define the DAG
 dag = DAG(
-    'fetch_and_CJU_parking_data',
+    'update_CJU_parking_data',
     default_args=default_args,
-    description='Fetch parking data from OpenAPI for GMP and CJU and store in GCS every 5 minutes',
+    description='A DAG to update parking data every 5 minutes and save it to GCS',
     schedule_interval='*/5 * * * *',
     catchup=False,
 )
 
-# Define the task
 fetch_and_upload_task = PythonOperator(
     task_id='fetch_and_upload_CJU_parking_data',
     python_callable=update_parking_data,
     dag=dag,
 )
 
-upload_to_gcs_task = LocalFilesystemToGCSOperator(
-    task_id='upload_CJU_parking_data', # 개발자의 task 정의에 따라 임의로 입력
-    src='/tmp/CJU_parking_data.csv', # API에서 받아온 데이터를 로컬에 csv로 먼저 저장한 상황을 가정하며 해당 csv파일 위치 입력
-    dst='source/source_parkinglot/CJU_parking_data/2024/06/{{ execution_date.strftime("%d") }}/CJU_parking_data_{{ execution_date.strftime("%Y%m%d") }}.csv',
-    bucket='pdc3project-landing-zone-bucket',
-    gcp_conn_id='google_cloud_GCS',
+set_kst_task = PythonOperator(
+    task_id='set_kst_execution_date',
+    python_callable=set_kst_execution_date,
+    provide_context=True,
     dag=dag,
 )
 
-fetch_and_upload_task>>upload_to_gcs_task
+upload_to_gcs_task = PythonOperator(
+    task_id='upload_CJU_airplane_parking_data',
+    python_callable=upload_to_gcs_callable,
+    provide_context=True,
+    dag=dag,
+)
+
+fetch_and_upload_task >> set_kst_task >> upload_to_gcs_task

--- a/dags/CJU_Parking.py
+++ b/dags/CJU_Parking.py
@@ -40,14 +40,16 @@ def parse_xml_data(xml_data):
         sysGetdate = item.find('sysGetdate').text
         sysGettime = item.find('sysGettime').text
         datetm = calculate_date(sysGetdate, sysGettime)
-
+        degree = int(item.find('parkingCongestionDegree').text[:2])
+        if degree >= 100:
+            degree =int(100)
         items.append({
             'airportKor': item.find('airportKor').text,
             'parkingAirportCodeName': item.find('parkingAirportCodeName').text,
             'parkingCongestion': item.find('parkingCongestion').text,
-            'parkingCongestionDegree': int(item.find('parkingCongestionDegree').text[:2]),
-            'parkingOccupiedSpace': item.find('parkingOccupiedSpace').text,
-            'parkingTotalSpace': item.find('parkingTotalSpace').text,
+            'parkingCongestionDegree': int(degree),
+            'parkingOccupiedSpace': int(item.find('parkingOccupiedSpace').text),
+            'parkingTotalSpace': int(item.find('parkingTotalSpace').text),
             'datetm': datetm
         })
     return items
@@ -58,7 +60,7 @@ def update_parking_data():
     data_gmp = fetch_xml_data('CJU')
     parsed_data_gmp = parse_xml_data(data_gmp)
     df = pd.DataFrame(parsed_data_gmp)
-    df.to_csv('/tmp/GMP_parking_data.csv', index=False, encoding='utf-8-sig')
+    df.to_csv('/tmp/CJU_parking_data.csv', index=False, encoding='utf-8-sig')
     print("Domestic data fetched and saved to '/tmp/CJU_parking_data.csv'")
 
 

--- a/dags/GMP_Parking.py
+++ b/dags/GMP_Parking.py
@@ -1,5 +1,5 @@
 from airflow import DAG
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.providers.google.cloud.transfers.local_to_gcs import LocalFilesystemToGCSOperator
 from airflow.utils.dates import days_ago
 from datetime import datetime, timedelta
@@ -8,9 +8,10 @@ import pandas as pd
 import xml.etree.ElementTree as ET
 from airflow.models import Variable
 from plugins import slack
-import json
+import pytz
 
 
+# Function to fetch XML data from the API
 def fetch_xml_data(airport_code):
     url = 'http://openapi.airport.co.kr/service/rest/AirportParkingCongestion/airportParkingCongestionRT'
     parking_api_key = Variable.get('parking_api_key')
@@ -25,11 +26,13 @@ def fetch_xml_data(airport_code):
     response.raise_for_status()
     return response.text
 
+
+# Function to calculate parking congestion degree and status
+
 def calculate_date(sysGetdate, sysGettime):
     datetm = f"{sysGetdate[:4]}{sysGetdate[5:7]}{sysGetdate[8:]}{sysGettime[:2]}{sysGettime[3:5]}{sysGettime[6:]}"
     return datetm
 
-# Function to fetch parking data for a specific airport code
 def parse_xml_data(xml_data):
     root = ET.fromstring(xml_data)
     items = []
@@ -56,10 +59,47 @@ def update_parking_data():
     parsed_data_gmp = parse_xml_data(data_gmp)
     df = pd.DataFrame(parsed_data_gmp)
     df.to_csv('/tmp/GMP_parking_data.csv', index=False, encoding='utf-8-sig')
-    print("Domestic data fetched and saved to '/tmp/GMP_parking_data.csv'")
+    print("Domestic data fetched and saved to '/tmp/CJU_parking_data.csv'")
 
 
-# Default settings for the DAG
+# Convert UTC to KST
+def convert_to_kst(execution_date):
+    # UTC에서 한국 시간으로 변환
+    execution_date_utc = execution_date.replace(tzinfo=pytz.UTC)
+    execution_date_kst = execution_date_utc.astimezone(pytz.timezone('Asia/Seoul'))
+    return execution_date_kst.strftime('%Y-%m-%d %H:%M:%S')
+
+def set_kst_execution_date(**kwargs):
+    # Airflow의 execution_date를 가져와서 한국 시간대로 변환 후 XCom에 저장
+    execution_date = kwargs['execution_date']
+    execution_date_kst = convert_to_kst(execution_date)
+    ti = kwargs['ti']
+    ti.xcom_push(key='execution_date_kst', value=execution_date_kst)
+
+# Function to retrieve the KST execution date from XCom and format the destination path
+def get_kst_execution_date_path(**kwargs):
+    ti = kwargs['ti']
+    execution_date_kst = ti.xcom_pull(task_ids='set_kst_execution_date', key='execution_date_kst')
+    # Convert the pulled execution_date_kst string back to a datetime object
+    execution_date_kst_dt = datetime.strptime(execution_date_kst, '%Y-%m-%d %H:%M:%S')
+    formatted_day = execution_date_kst_dt.strftime("%d")
+    formatted_timestamp = execution_date_kst_dt.strftime("%Y%m%d%H%M")
+    return f'source/source_parkinglot/GMP_parking_data/2024/06/{formatted_day}/GMP_parking_data_{formatted_timestamp}.csv'
+
+def upload_to_gcs_callable(**kwargs):
+    dst_path = get_kst_execution_date_path(**kwargs)
+    # Use the path in LocalFilesystemToGCSOperator
+    LocalFilesystemToGCSOperator(
+        task_id='upload_GMP_parking_data',
+        src='/tmp/GMP_parking_data.csv',
+        dst=dst_path,
+        bucket='pdc3project-landing-zone-bucket',
+        gcp_conn_id='google_cloud_GCS',
+        dag=kwargs['dag'],
+    ).execute(kwargs)
+
+
+# Define the default_args for the DAG
 default_args = {
     'owner': 'airflow',
     'start_date': days_ago(1),
@@ -70,27 +110,31 @@ default_args = {
 
 # Define the DAG
 dag = DAG(
-    'fetch_and_GMP_parking_data',
+    'update_GMP_parking_data',
     default_args=default_args,
-    description='Fetch parking data from OpenAPI for GMP and CJU and store in GCS every 5 minutes',
+    description='A DAG to update parking data every 5 minutes and save it to GCS',
     schedule_interval='*/5 * * * *',
     catchup=False,
 )
 
-# Define the task
 fetch_and_upload_task = PythonOperator(
     task_id='fetch_and_upload_GMP_parking_data',
     python_callable=update_parking_data,
     dag=dag,
 )
 
-upload_to_gcs_task = LocalFilesystemToGCSOperator(
-    task_id='upload_GMP_parking_data', # 개발자의 task 정의에 따라 임의로 입력
-    src='/tmp/GMP_parking_data.csv', # API에서 받아온 데이터를 로컬에 csv로 먼저 저장한 상황을 가정하며 해당 csv파일 위치 입력
-    dst='source/source_parkinglot/GMP_parking_data/2024/06/{{ execution_date.strftime("%d") }}/GMP_parking_data_{{ execution_date.strftime("%Y%m%d") }}.csv',
-    bucket='pdc3project-landing-zone-bucket',
-    gcp_conn_id='google_cloud_GCS',
+set_kst_task = PythonOperator(
+    task_id='set_kst_execution_date',
+    python_callable=set_kst_execution_date,
+    provide_context=True,
     dag=dag,
 )
 
-fetch_and_upload_task>>upload_to_gcs_task
+upload_to_gcs_task = PythonOperator(
+    task_id='upload_GMP_airplane_parking_data',
+    python_callable=upload_to_gcs_callable,
+    provide_context=True,
+    dag=dag,
+)
+
+fetch_and_upload_task >> set_kst_task >> upload_to_gcs_task

--- a/dags/GMP_Parking.py
+++ b/dags/GMP_Parking.py
@@ -45,7 +45,7 @@ def parse_xml_data(xml_data):
             'airportKor': item.find('airportKor').text,
             'parkingAirportCodeName': item.find('parkingAirportCodeName').text,
             'parkingCongestion': item.find('parkingCongestion').text,
-            'parkingCongestionDegree': item.find('parkingCongestionDegree').text,
+            'parkingCongestionDegree': int(item.find('parkingCongestionDegree').text[:2]),
             'parkingOccupiedSpace': item.find('parkingOccupiedSpace').text,
             'parkingTotalSpace': item.find('parkingTotalSpace').text,
             'datetm': datetm

--- a/dags/GMP_Parking.py
+++ b/dags/GMP_Parking.py
@@ -40,14 +40,16 @@ def parse_xml_data(xml_data):
         sysGetdate = item.find('sysGetdate').text
         sysGettime = item.find('sysGettime').text
         datetm = calculate_date(sysGetdate, sysGettime)
-
+        degree = int(item.find('parkingCongestionDegree').text[:2])
+        if degree >= 100:
+            defree =100
         items.append({
             'airportKor': item.find('airportKor').text,
             'parkingAirportCodeName': item.find('parkingAirportCodeName').text,
             'parkingCongestion': item.find('parkingCongestion').text,
-            'parkingCongestionDegree': int(item.find('parkingCongestionDegree').text[:2]),
-            'parkingOccupiedSpace': item.find('parkingOccupiedSpace').text,
-            'parkingTotalSpace': item.find('parkingTotalSpace').text,
+            'parkingCongestionDegree': int(degree),
+            'parkingOccupiedSpace': int(item.find('parkingOccupiedSpace').text),
+            'parkingTotalSpace': int(item.find('parkingTotalSpace').text),
             'datetm': datetm
         })
     return items

--- a/dags/INT_Parking.py
+++ b/dags/INT_Parking.py
@@ -33,7 +33,7 @@ def calculate_congestion(parking, parkingarea):
         congestion = '혼잡'
     else:
         congestion = '만차'
-    return degree, congestion
+    return int(degree), congestion
 
 def parse_xml_data(xml_data):
     root = ET.fromstring(xml_data)
@@ -47,7 +47,7 @@ def parse_xml_data(xml_data):
             'airportKor': '인천국제공항',
             'parkingAirportCodeName': item.find('floor').text,
             'parkingCongestion': congestion,
-            'parkingCongestionDegree': f"{degree:.2f}%",
+            'parkingCongestionDegree': degree,
             'parkingOccupiedSpace': parking,
             'parkingTotalSpace': parkingarea,
             'datetm': item.find('datetm').text[:14]

--- a/dags/INT_Parking.py
+++ b/dags/INT_Parking.py
@@ -33,6 +33,7 @@ def calculate_congestion(parking, parkingarea):
         congestion = '혼잡'
     else:
         congestion = '만차'
+        degree=100
     return int(degree), congestion
 
 def parse_xml_data(xml_data):
@@ -47,7 +48,7 @@ def parse_xml_data(xml_data):
             'airportKor': '인천국제공항',
             'parkingAirportCodeName': item.find('floor').text,
             'parkingCongestion': congestion,
-            'parkingCongestionDegree': degree,
+            'parkingCongestionDegree': int(degree),
             'parkingOccupiedSpace': parking,
             'parkingTotalSpace': parkingarea,
             'datetm': item.find('datetm').text[:14]

--- a/dags/INT_Parking.py
+++ b/dags/INT_Parking.py
@@ -8,7 +8,7 @@ import pandas as pd
 import xml.etree.ElementTree as ET
 from airflow.models import Variable
 from plugins import slack
-import json
+import pytz
 
 
 # Function to fetch XML data from the API
@@ -35,8 +35,6 @@ def calculate_congestion(parking, parkingarea):
         congestion = '만차'
     return degree, congestion
 
-
-# Function to parse the XML data and extract the required fields
 def parse_xml_data(xml_data):
     root = ET.fromstring(xml_data)
     items = []
@@ -64,7 +62,44 @@ def update_parking_data():
     parsed_data_int = parse_xml_data(data_int)
     df = pd.DataFrame(parsed_data_int)
     df.to_csv('/tmp/INT_parking_data.csv', index=False, encoding='utf-8-sig')
-    print("Domestic data fetched and saved to '/tmp/INT_parking_data.csv'")
+    print("International data fetched and saved to '/tmp/INT_parking_data.csv'")
+
+
+# Convert UTC to KST
+def convert_to_kst(execution_date):
+    # UTC에서 한국 시간으로 변환
+    execution_date_utc = execution_date.replace(tzinfo=pytz.UTC)
+    execution_date_kst = execution_date_utc.astimezone(pytz.timezone('Asia/Seoul'))
+    return execution_date_kst.strftime('%Y-%m-%d %H:%M:%S')
+
+def set_kst_execution_date(**kwargs):
+    # Airflow의 execution_date를 가져와서 한국 시간대로 변환 후 XCom에 저장
+    execution_date = kwargs['execution_date']
+    execution_date_kst = convert_to_kst(execution_date)
+    ti = kwargs['ti']
+    ti.xcom_push(key='execution_date_kst', value=execution_date_kst)
+
+# Function to retrieve the KST execution date from XCom and format the destination path
+def get_kst_execution_date_path(**kwargs):
+    ti = kwargs['ti']
+    execution_date_kst = ti.xcom_pull(task_ids='set_kst_execution_date', key='execution_date_kst')
+    # Convert the pulled execution_date_kst string back to a datetime object
+    execution_date_kst_dt = datetime.strptime(execution_date_kst, '%Y-%m-%d %H:%M:%S')
+    formatted_day = execution_date_kst_dt.strftime("%d")
+    formatted_timestamp = execution_date_kst_dt.strftime("%Y%m%d%H%M")
+    return f'source/source_parkinglot/INT_parking_data/2024/06/{formatted_day}/INT_parking_data_{formatted_timestamp}.csv'
+
+def upload_to_gcs_callable(**kwargs):
+    dst_path = get_kst_execution_date_path(**kwargs)
+    # Use the path in LocalFilesystemToGCSOperator
+    LocalFilesystemToGCSOperator(
+        task_id='upload_INT_parking_data',
+        src='/tmp/INT_parking_data.csv',
+        dst=dst_path,
+        bucket='pdc3project-landing-zone-bucket',
+        gcp_conn_id='google_cloud_GCS',
+        dag=kwargs['dag'],
+    ).execute(kwargs)
 
 
 # Define the default_args for the DAG
@@ -78,11 +113,11 @@ default_args = {
 
 # Define the DAG
 dag = DAG(
-        'update_INT_parking_data',
-        default_args=default_args,
-        description='A DAG to update parking data every 5 minutes and save it to GCS',
-        schedule_interval='*/5 * * * *',
-        catchup=False,
+    'update_INT_parking_data',
+    default_args=default_args,
+    description='A DAG to update parking data every 5 minutes and save it to GCS',
+    schedule_interval='*/5 * * * *',
+    catchup=False,
 )
 
 fetch_and_upload_task = PythonOperator(
@@ -91,15 +126,18 @@ fetch_and_upload_task = PythonOperator(
     dag=dag,
 )
 
-
-upload_to_gcs_task = LocalFilesystemToGCSOperator(
-    task_id='upload_INT_parking_data', # 개발자의 task 정의에 따라 임의로 입력
-    src='/tmp/INT_parking_data.csv', # API에서 받아온 데이터를 로컬에 csv로 먼저 저장한 상황을 가정하며 해당 csv파일 위치 입력
-    dst='source/source_parkinglot/INT_parking_data/2024/06/{{ execution_date.strftime("%d") }}/INT_parking_data_{{ execution_date.strftime("%Y%m%d") }}.csv',
-    bucket='pdc3project-landing-zone-bucket',
-    gcp_conn_id='google_cloud_GCS',
+set_kst_task = PythonOperator(
+    task_id='set_kst_execution_date',
+    python_callable=set_kst_execution_date,
+    provide_context=True,
     dag=dag,
 )
 
-fetch_and_upload_task>>upload_to_gcs_task
+upload_to_gcs_task = PythonOperator(
+    task_id='upload_INT_airplane_parking_data',
+    python_callable=upload_to_gcs_callable,
+    provide_context=True,
+    dag=dag,
+)
 
+fetch_and_upload_task >> set_kst_task >> upload_to_gcs_task

--- a/dags/Parking_CJU_ELT.py
+++ b/dags/Parking_CJU_ELT.py
@@ -109,7 +109,7 @@ default_args = {
 }
 
 dag = DAG(
-    'GMP_csv_to_parquet',
+    'BQ_CJU_csv_to_parquet',
     default_args=default_args,
     description='CSV 데이터를 Parquet으로 변환하여 GCS에 저장하는 DAG',
     schedule_interval='*/5 * * * *',
@@ -171,8 +171,8 @@ load_to_bigquery_task = GCSToBigQueryOperator(
         {'name': 'airportKor', 'type': 'STRING', 'mode': 'NULLABLE'},
         {'name': 'parkingAirportCodeName', 'type': 'STRING', 'mode': 'NULLABLE'},
         {'name': 'parkingCongestion', 'type': 'STRING', 'mode': 'NULLABLE'},
-        {'name': 'parkingCongestionDegree', 'type': 'INTEGER', 'mode': 'NULLABLE'},
-        {'name': 'parkingOccupiedSpace', 'type': 'INTEGER', 'mode': 'NULLABLE'},  # INT64 호환을 위해 INTEGER로 변경
+        {'name': 'parkingCongestionDegree', 'type':'INTEGER', 'mode': 'NULLABLE'},
+        {'name': 'parkingOccupiedSpace', 'type':'INTEGER', 'mode': 'NULLABLE'},  # INT64 호환을 위해 INTEGER로 변경
         {'name': 'parkingTotalSpace','type': 'INTEGER', 'mode': 'NULLABLE'},
         {'name': 'datetm', 'type': 'INTEGER', 'mode': 'NULLABLE'},
     ],

--- a/dags/Parking_CJU_ELT.py
+++ b/dags/Parking_CJU_ELT.py
@@ -1,0 +1,140 @@
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from airflow.providers.google.cloud.hooks.gcs import GCSHook
+from airflow.providers.google.cloud.transfers.gcs_to_bigquery import GCSToBigQueryOperator
+from airflow.utils.dates import days_ago
+from datetime import datetime, timedelta
+import pyarrow.parquet as pq
+import pandas as pd
+import pyarrow as pa
+from plugins import slack
+import pytz
+import re
+
+
+def convert_to_kst(execution_date):
+    # UTC에서 한국 시간으로 변환
+    execution_date_utc = execution_date.replace(tzinfo=pytz.UTC)
+    execution_date_kst = execution_date_utc.astimezone(pytz.timezone('Asia/Seoul'))
+    return execution_date_kst.strftime('%Y-%m-%d %H:%M:%S')
+
+def set_kst_execution_date(**kwargs):
+    # Airflow의 execution_date를 가져와서 한국 시간대로 변환 후 XCom에 저장
+    execution_date = kwargs['execution_date']
+    execution_date_kst = convert_to_kst(execution_date)
+    ti = kwargs['ti']
+    ti.xcom_push(key='execution_date_kst', value=execution_date_kst)
+
+def extract_csv_from_gcs(execution_date_str, **kwargs):
+    ti = kwargs['ti']
+    execution_date_kst = ti.xcom_pull(task_ids='set_kst_execution_date', key='execution_date_kst')
+    # Convert the pulled execution_date_kst string back to a datetime object
+    execution_date_kst_dt = datetime.strptime(execution_date_kst, '%Y-%m-%d %H:%M:%S')
+    formatted_day = execution_date_kst_dt.strftime("%d")
+    formatted_timestamp = execution_date_kst_dt.strftime("%Y%m%d%H")
+    gcs_hook = GCSHook(gcp_conn_id='google_cloud_GCS')
+    bucket_name = 'pdc3project-landing-zone-bucket'
+
+    # GCS 객체의 prefix와 정규 표현식 패턴을 설정
+    prefix = f'source/source_parkinglot/CJU_parking_data/2024/06/{formatted_day}'
+    regex_pattern = f'CJU_parking_data_{formatted_timestamp}\d{{2}}.csv'
+
+    # 지정된 GCS prefix에서 모든 파일 리스트를 가져옴
+    objects = gcs_hook.list(bucket_name, prefix=prefix)
+
+    # 정규 표현식 패턴과 일치하는 파일을 찾음
+    matching_files = [obj for obj in objects if re.search(regex_pattern, obj)]
+
+    if not matching_files:
+        raise FileNotFoundError(f"No files matching pattern {regex_pattern} in {prefix}")
+
+    # 첫 번째로 일치하는 파일을 다운로드
+    object_name = matching_files[0]
+    local_path = '/tmp/CJU_parking_data.csv'
+    gcs_hook.download(bucket_name, object_name, local_path)
+
+
+def transform_csv_to_parquet(execution_date_str, **kwargs):
+    # 로컬에 저장된 CSV 파일 경로를 설정
+    local_csv_path = '/tmp/CJU_parking_data.csv'
+    df = pd.read_csv(local_csv_path)
+
+    # Parquet 파일로 저장할 경로를 설정
+    parquet_path = '/tmp/CJU_parking_data.parquet'
+    table = pa.Table.from_pandas(df)
+    pq.write_table(table, parquet_path)
+
+    # 현재 태스크 인스턴스를 나타내는 task_instance 객체를 가져옴
+    ti = kwargs['ti']
+
+    # XCom을 사용하여 Parquet 파일 경로를 push(저장)
+    ti.xcom_push(key='parquet_path', value=parquet_path)
+
+
+def upload_to_gcs(execution_date_str, **kwargs):
+    # 현재 태스크 인스턴스를 나타내는 task_instance 객체를 가져옴
+    ti = kwargs['ti']
+    execution_date_kst = ti.xcom_pull(task_ids='set_kst_execution_date', key='execution_date_kst')
+    # Convert the pulled execution_date_kst string back to a datetime object
+    execution_date_kst_dt = datetime.strptime(execution_date_kst, '%Y-%m-%d %H:%M:%S')
+    formatted_day = execution_date_kst_dt.strftime("%d")
+    formatted_timestamp = execution_date_kst_dt.strftime("%Y%m%d%H%M")
+    # 이전 태스크에서 저장된 Parquet 파일 경로를 XCom을 통해 가져옴
+    parquet_path = ti.xcom_pull(key='parquet_path', task_ids='transform_csv_to_parquet')
+
+    # execution_date_str을 datetime 객체로 변환
+    execution_date = datetime.strptime(execution_date_str, '%Y-%m-%dT%H:%M:%S%z')
+    bucket = 'pdc3project-stage-layer-bucket'
+    gcs_hook = GCSHook(gcp_conn_id='google_cloud_GCS')
+    dst_path = f'source/source_parkinglot/CJU_parking_data/2024/06/{formatted_day}/CJU_parking_data_{formatted_timestamp}.parquet'
+
+    # Parquet 파일을 GCS에 업로드
+    gcs_hook.upload(bucket_name=bucket, object_name=dst_path, filename=parquet_path)
+
+
+default_args = {
+    'owner': 'airflow',
+    'start_date': days_ago(1),
+    'retries': 1,
+    'retry_delay': timedelta(minutes=1),
+    'on_failure_callback': slack.on_failure_callback,
+}
+
+dag = DAG(
+    'CJU_csv_to_parquet',
+    default_args=default_args,
+    description='CSV 데이터를 Parquet으로 변환하여 GCS에 저장하는 DAG',
+    schedule_interval='*/5 * * * *',
+    max_active_runs=1,
+    catchup=False,
+)
+
+set_kst_task = PythonOperator(
+    task_id='set_kst_execution_date',
+    python_callable=set_kst_execution_date,
+    provide_context=True,
+    dag=dag,
+)
+
+extract_task = PythonOperator(
+    task_id='extract_csv_from_gcs',
+    python_callable=extract_csv_from_gcs,
+    op_kwargs={'execution_date_str': '{{ ts }}'},  # ts는 실행 날짜와 시간을 문자열로 반환합니다.
+    dag=dag,
+)
+
+transform_task = PythonOperator(
+    task_id='transform_csv_to_parquet',
+    python_callable=transform_csv_to_parquet,
+    op_kwargs={'execution_date_str': '{{ ts }}'},
+    dag=dag,
+)
+
+upload_task = PythonOperator(
+    task_id='upload_to_gcs',
+    python_callable=upload_to_gcs,
+    op_kwargs={'execution_date_str': '{{ ts }}'},
+    dag=dag,
+)
+
+set_kst_task >> extract_task >> transform_task >> upload_task

--- a/dags/Parking_CJU_ELT.py
+++ b/dags/Parking_CJU_ELT.py
@@ -25,24 +25,28 @@ def set_kst_execution_date(**kwargs):
     ti = kwargs['ti']
     ti.xcom_push(key='execution_date_kst', value=execution_date_kst)
 
-def extract_csv_from_gcs(execution_date_str, **kwargs):
-    ti = kwargs['ti']
+def formatted_days(ti):
+    # XCom을 사용하여 execution_date_kst를 가져옴
     execution_date_kst = ti.xcom_pull(task_ids='set_kst_execution_date', key='execution_date_kst')
     # Convert the pulled execution_date_kst string back to a datetime object
     execution_date_kst_dt = datetime.strptime(execution_date_kst, '%Y-%m-%d %H:%M:%S')
     formatted_day = execution_date_kst_dt.strftime("%d")
-    formatted_timestamp = execution_date_kst_dt.strftime("%Y%m%d%H")
+    formatted_hour = execution_date_kst_dt.strftime("%Y%m%d%H")
+    formatted_timestamp = execution_date_kst_dt.strftime("%Y%m%d%H%M")
+    return formatted_day, formatted_hour, formatted_timestamp
+
+def extract_csv_from_gcs(execution_date_str, **kwargs):
+    ti = kwargs['ti']
+    formatted_day, formatted_hour, formatted_timestamp = formatted_days(ti)
     gcs_hook = GCSHook(gcp_conn_id='google_cloud_GCS')
     bucket_name = 'pdc3project-landing-zone-bucket'
 
     # GCS 객체의 prefix와 정규 표현식 패턴을 설정
     prefix = f'source/source_parkinglot/CJU_parking_data/2024/06/{formatted_day}'
-    regex_pattern = f'CJU_parking_data_{formatted_timestamp}\d{{2}}.csv'
+    regex_pattern = f'CJU_parking_data_{formatted_hour}\d{{2}}.csv'
 
-    # 지정된 GCS prefix에서 모든 파일 리스트를 가져옴
     objects = gcs_hook.list(bucket_name, prefix=prefix)
 
-    # 정규 표현식 패턴과 일치하는 파일을 찾음
     matching_files = [obj for obj in objects if re.search(regex_pattern, obj)]
 
     if not matching_files:
@@ -52,6 +56,9 @@ def extract_csv_from_gcs(execution_date_str, **kwargs):
     object_name = matching_files[0]
     local_path = '/tmp/CJU_parking_data.csv'
     gcs_hook.download(bucket_name, object_name, local_path)
+
+    # 다음 Task에 필요한 값을 XCom을 통해 전달
+    return {'formatted_day': formatted_day, 'formatted_timestamp': formatted_timestamp}
 
 
 def transform_csv_to_parquet(execution_date_str, **kwargs):
@@ -77,6 +84,7 @@ def upload_to_gcs(execution_date_str, **kwargs):
     execution_date_kst = ti.xcom_pull(task_ids='set_kst_execution_date', key='execution_date_kst')
     # Convert the pulled execution_date_kst string back to a datetime object
     execution_date_kst_dt = datetime.strptime(execution_date_kst, '%Y-%m-%d %H:%M:%S')
+    execution_date_kst_dt += timedelta(minutes=5)
     formatted_day = execution_date_kst_dt.strftime("%d")
     formatted_timestamp = execution_date_kst_dt.strftime("%Y%m%d%H%M")
     # 이전 태스크에서 저장된 Parquet 파일 경로를 XCom을 통해 가져옴
@@ -101,7 +109,7 @@ default_args = {
 }
 
 dag = DAG(
-    'CJU_csv_to_parquet',
+    'GMP_csv_to_parquet',
     default_args=default_args,
     description='CSV 데이터를 Parquet으로 변환하여 GCS에 저장하는 DAG',
     schedule_interval='*/5 * * * *',
@@ -119,7 +127,8 @@ set_kst_task = PythonOperator(
 extract_task = PythonOperator(
     task_id='extract_csv_from_gcs',
     python_callable=extract_csv_from_gcs,
-    op_kwargs={'execution_date_str': '{{ ts }}'},  # ts는 실행 날짜와 시간을 문자열로 반환합니다.
+    op_kwargs={'execution_date_str': '{{ ts }}'},
+    provide_context=True,
     dag=dag,
 )
 
@@ -127,6 +136,7 @@ transform_task = PythonOperator(
     task_id='transform_csv_to_parquet',
     python_callable=transform_csv_to_parquet,
     op_kwargs={'execution_date_str': '{{ ts }}'},
+    provide_context=True,
     dag=dag,
 )
 
@@ -134,7 +144,42 @@ upload_task = PythonOperator(
     task_id='upload_to_gcs',
     python_callable=upload_to_gcs,
     op_kwargs={'execution_date_str': '{{ ts }}'},
+    provide_context=True,
     dag=dag,
 )
 
-set_kst_task >> extract_task >> transform_task >> upload_task
+airport = 'CJU'
+bq_tasks = []
+tz = pytz.timezone('Asia/Seoul')
+now = datetime.now(tz)
+
+formatted_day = now.strftime("%d")
+rounded_minute = now.minute - (now.minute % 5)
+rounded_time = now.replace(minute=rounded_minute, second=0, microsecond=0)
+formatted_timestamp = rounded_time.strftime("%Y%m%d%H%M")
+source_object=[f'source/source_parkinglot/CJU_parking_data/2024/06/{formatted_day}/CJU_parking_data_{formatted_timestamp}.parquet']
+
+# GCSToBigQueryOperator에 대한 설정
+load_to_bigquery_task = GCSToBigQueryOperator(
+    task_id=f'load_{airport}_to_bigquery',
+    bucket='pdc3project-stage-layer-bucket',
+    source_objects=source_object,
+    destination_project_dataset_table=f'pdc3project.raw_data.parking_data_{airport}',
+    source_format='PARQUET',
+    write_disposition='WRITE_APPEND',
+    schema_fields=[
+        {'name': 'airportKor', 'type': 'STRING', 'mode': 'NULLABLE'},
+        {'name': 'parkingAirportCodeName', 'type': 'STRING', 'mode': 'NULLABLE'},
+        {'name': 'parkingCongestion', 'type': 'STRING', 'mode': 'NULLABLE'},
+        {'name': 'parkingCongestionDegree', 'type': 'INTEGER', 'mode': 'NULLABLE'},
+        {'name': 'parkingOccupiedSpace', 'type': 'INTEGER', 'mode': 'NULLABLE'},  # INT64 호환을 위해 INTEGER로 변경
+        {'name': 'parkingTotalSpace','type': 'INTEGER', 'mode': 'NULLABLE'},
+        {'name': 'datetm', 'type': 'INTEGER', 'mode': 'NULLABLE'},
+    ],
+    gcp_conn_id='google_cloud_bigquery',
+    dag=dag,
+)
+
+bq_tasks.append(load_to_bigquery_task)
+
+extract_task >> transform_task >> upload_task >> bq_tasks

--- a/dags/Parking_GMP_ELT.py
+++ b/dags/Parking_GMP_ELT.py
@@ -14,8 +14,8 @@ import re
 
 def convert_to_kst(execution_date):
     execution_date_utc = execution_date.replace(tzinfo=pytz.UTC)
-    execution_date_kst = execution_date_utc.astimezone(pytz.timezone('Asia/Seoul'))
-    return execution_date_kst.strftime('%Y-%m-%d %H:%M:%S')
+    execution_date_korea = execution_date_utc.astimezone(pytz.timezone('Asia/Seoul'))
+    return execution_date_korea.strftime('%Y-%m-%d %H:%M:%S')
 
 def set_kst_execution_date(**kwargs):
     # Airflow의 execution_date를 가져와서 한국 시간대로 변환 후 XCom에 저장

--- a/dags/Parking_GMP_ELT.py
+++ b/dags/Parking_GMP_ELT.py
@@ -18,14 +18,12 @@ def convert_to_kst(execution_date):
     execution_date_kst = execution_date_utc.astimezone(pytz.timezone('Asia/Seoul'))
     return execution_date_kst.strftime('%Y-%m-%d %H:%M:%S')
 
-
 def set_kst_execution_date(**kwargs):
     # Airflow의 execution_date를 가져와서 한국 시간대로 변환 후 XCom에 저장
     execution_date = kwargs['execution_date']
     execution_date_kst = convert_to_kst(execution_date)
     ti = kwargs['ti']
     ti.xcom_push(key='execution_date_kst', value=execution_date_kst)
-
 
 def formatted_days(ti):
     # XCom을 사용하여 execution_date_kst를 가져옴
@@ -36,7 +34,6 @@ def formatted_days(ti):
     formatted_hour = execution_date_kst_dt.strftime("%Y%m%d%H")
     formatted_timestamp = execution_date_kst_dt.strftime("%Y%m%d%H%M")
     return formatted_day, formatted_hour, formatted_timestamp
-
 
 def extract_csv_from_gcs(execution_date_str, **kwargs):
     ti = kwargs['ti']
@@ -112,7 +109,7 @@ default_args = {
 }
 
 dag = DAG(
-    'GMP_csv_to_parquet',
+    'BQ_GMP_csv_to_parquet',
     default_args=default_args,
     description='CSV 데이터를 Parquet으로 변환하여 GCS에 저장하는 DAG',
     schedule_interval='*/5 * * * *',
@@ -160,8 +157,7 @@ formatted_day = now.strftime("%d")
 rounded_minute = now.minute - (now.minute % 5)
 rounded_time = now.replace(minute=rounded_minute, second=0, microsecond=0)
 formatted_timestamp = rounded_time.strftime("%Y%m%d%H%M")
-source_object = [
-    f'source/source_parkinglot/GMP_parking_data/2024/06/{formatted_day}/GMP_parking_data_{formatted_timestamp}.parquet']
+source_object=[f'source/source_parkinglot/GMP_parking_data/2024/06/{formatted_day}/GMP_parking_data_{formatted_timestamp}.parquet']
 
 # GCSToBigQueryOperator에 대한 설정
 load_to_bigquery_task = GCSToBigQueryOperator(
@@ -175,9 +171,9 @@ load_to_bigquery_task = GCSToBigQueryOperator(
         {'name': 'airportKor', 'type': 'STRING', 'mode': 'NULLABLE'},
         {'name': 'parkingAirportCodeName', 'type': 'STRING', 'mode': 'NULLABLE'},
         {'name': 'parkingCongestion', 'type': 'STRING', 'mode': 'NULLABLE'},
-        {'name': 'parkingCongestionDegree', 'type': 'INTEGER', 'mode': 'NULLABLE'},
-        {'name': 'parkingOccupiedSpace', 'type': 'INTEGER', 'mode': 'NULLABLE'},  # INT64 호환을 위해 INTEGER로 변경
-        {'name': 'parkingTotalSpace', 'type': 'INTEGER', 'mode': 'NULLABLE'},
+        {'name': 'parkingCongestionDegree', 'type':'INTEGER', 'mode': 'NULLABLE'},
+        {'name': 'parkingOccupiedSpace', 'type':'INTEGER', 'mode': 'NULLABLE'},  # INT64 호환을 위해 INTEGER로 변경
+        {'name': 'parkingTotalSpace','type': 'INTEGER', 'mode': 'NULLABLE'},
         {'name': 'datetm', 'type': 'INTEGER', 'mode': 'NULLABLE'},
     ],
     gcp_conn_id='google_cloud_bigquery',

--- a/dags/Parking_GMP_ELT.py
+++ b/dags/Parking_GMP_ELT.py
@@ -13,7 +13,6 @@ import re
 
 
 def convert_to_kst(execution_date):
-    # UTC에서 한국 시간으로 변환
     execution_date_utc = execution_date.replace(tzinfo=pytz.UTC)
     execution_date_kst = execution_date_utc.astimezone(pytz.timezone('Asia/Seoul'))
     return execution_date_kst.strftime('%Y-%m-%d %H:%M:%S')

--- a/dags/Parking_GMP_ELT.py
+++ b/dags/Parking_GMP_ELT.py
@@ -1,0 +1,140 @@
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from airflow.providers.google.cloud.hooks.gcs import GCSHook
+from airflow.providers.google.cloud.transfers.gcs_to_bigquery import GCSToBigQueryOperator
+from airflow.utils.dates import days_ago
+from datetime import datetime, timedelta
+import pyarrow.parquet as pq
+import pandas as pd
+import pyarrow as pa
+from plugins import slack
+import pytz
+import re
+
+
+def convert_to_kst(execution_date):
+    # UTC에서 한국 시간으로 변환
+    execution_date_utc = execution_date.replace(tzinfo=pytz.UTC)
+    execution_date_kst = execution_date_utc.astimezone(pytz.timezone('Asia/Seoul'))
+    return execution_date_kst.strftime('%Y-%m-%d %H:%M:%S')
+
+def set_kst_execution_date(**kwargs):
+    # Airflow의 execution_date를 가져와서 한국 시간대로 변환 후 XCom에 저장
+    execution_date = kwargs['execution_date']
+    execution_date_kst = convert_to_kst(execution_date)
+    ti = kwargs['ti']
+    ti.xcom_push(key='execution_date_kst', value=execution_date_kst)
+
+def extract_csv_from_gcs(execution_date_str, **kwargs):
+    ti = kwargs['ti']
+    execution_date_kst = ti.xcom_pull(task_ids='set_kst_execution_date', key='execution_date_kst')
+    # Convert the pulled execution_date_kst string back to a datetime object
+    execution_date_kst_dt = datetime.strptime(execution_date_kst, '%Y-%m-%d %H:%M:%S')
+    formatted_day = execution_date_kst_dt.strftime("%d")
+    formatted_timestamp = execution_date_kst_dt.strftime("%Y%m%d%H")
+    gcs_hook = GCSHook(gcp_conn_id='google_cloud_GCS')
+    bucket_name = 'pdc3project-landing-zone-bucket'
+
+    # GCS 객체의 prefix와 정규 표현식 패턴을 설정
+    prefix = f'source/source_parkinglot/GMP_parking_data/2024/06/{formatted_day}'
+    regex_pattern = f'GMP_parking_data_{formatted_timestamp}\d{{2}}.csv'
+
+    # 지정된 GCS prefix에서 모든 파일 리스트를 가져옴
+    objects = gcs_hook.list(bucket_name, prefix=prefix)
+
+    # 정규 표현식 패턴과 일치하는 파일을 찾음
+    matching_files = [obj for obj in objects if re.search(regex_pattern, obj)]
+
+    if not matching_files:
+        raise FileNotFoundError(f"No files matching pattern {regex_pattern} in {prefix}")
+
+    # 첫 번째로 일치하는 파일을 다운로드
+    object_name = matching_files[0]
+    local_path = '/tmp/GMP_parking_data.csv'
+    gcs_hook.download(bucket_name, object_name, local_path)
+
+
+def transform_csv_to_parquet(execution_date_str, **kwargs):
+    # 로컬에 저장된 CSV 파일 경로를 설정
+    local_csv_path = '/tmp/GMP_parking_data.csv'
+    df = pd.read_csv(local_csv_path)
+
+    # Parquet 파일로 저장할 경로를 설정
+    parquet_path = '/tmp/GMP_parking_data.parquet'
+    table = pa.Table.from_pandas(df)
+    pq.write_table(table, parquet_path)
+
+    # 현재 태스크 인스턴스를 나타내는 task_instance 객체를 가져옴
+    ti = kwargs['ti']
+
+    # XCom을 사용하여 Parquet 파일 경로를 push(저장)
+    ti.xcom_push(key='parquet_path', value=parquet_path)
+
+
+def upload_to_gcs(execution_date_str, **kwargs):
+    # 현재 태스크 인스턴스를 나타내는 task_instance 객체를 가져옴
+    ti = kwargs['ti']
+    execution_date_kst = ti.xcom_pull(task_ids='set_kst_execution_date', key='execution_date_kst')
+    # Convert the pulled execution_date_kst string back to a datetime object
+    execution_date_kst_dt = datetime.strptime(execution_date_kst, '%Y-%m-%d %H:%M:%S')
+    formatted_day = execution_date_kst_dt.strftime("%d")
+    formatted_timestamp = execution_date_kst_dt.strftime("%Y%m%d%H%M")
+    # 이전 태스크에서 저장된 Parquet 파일 경로를 XCom을 통해 가져옴
+    parquet_path = ti.xcom_pull(key='parquet_path', task_ids='transform_csv_to_parquet')
+
+    # execution_date_str을 datetime 객체로 변환
+    execution_date = datetime.strptime(execution_date_str, '%Y-%m-%dT%H:%M:%S%z')
+    bucket = 'pdc3project-stage-layer-bucket'
+    gcs_hook = GCSHook(gcp_conn_id='google_cloud_GCS')
+    dst_path = f'source/source_parkinglot/GMP_parking_data/2024/06/{formatted_day}/GMP_parking_data_{formatted_timestamp}.parquet'
+
+    # Parquet 파일을 GCS에 업로드
+    gcs_hook.upload(bucket_name=bucket, object_name=dst_path, filename=parquet_path)
+
+
+default_args = {
+    'owner': 'airflow',
+    'start_date': days_ago(1),
+    'retries': 1,
+    'retry_delay': timedelta(minutes=1),
+    'on_failure_callback': slack.on_failure_callback,
+}
+
+dag = DAG(
+    'GMP_csv_to_parquet',
+    default_args=default_args,
+    description='CSV 데이터를 Parquet으로 변환하여 GCS에 저장하는 DAG',
+    schedule_interval='*/5 * * * *',
+    max_active_runs=1,
+    catchup=False,
+)
+
+set_kst_task = PythonOperator(
+    task_id='set_kst_execution_date',
+    python_callable=set_kst_execution_date,
+    provide_context=True,
+    dag=dag,
+)
+
+extract_task = PythonOperator(
+    task_id='extract_csv_from_gcs',
+    python_callable=extract_csv_from_gcs,
+    op_kwargs={'execution_date_str': '{{ ts }}'},  # ts는 실행 날짜와 시간을 문자열로 반환합니다.
+    dag=dag,
+)
+
+transform_task = PythonOperator(
+    task_id='transform_csv_to_parquet',
+    python_callable=transform_csv_to_parquet,
+    op_kwargs={'execution_date_str': '{{ ts }}'},
+    dag=dag,
+)
+
+upload_task = PythonOperator(
+    task_id='upload_to_gcs',
+    python_callable=upload_to_gcs,
+    op_kwargs={'execution_date_str': '{{ ts }}'},
+    dag=dag,
+)
+
+set_kst_task >> extract_task >> transform_task >> upload_task

--- a/dags/Parking_INT_ELT.py
+++ b/dags/Parking_INT_ELT.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta
 import pyarrow.parquet as pq
 import pandas as pd
 import pyarrow as pa
-from plugins import slack
 import pytz
 import re
 
@@ -25,19 +24,25 @@ def set_kst_execution_date(**kwargs):
     ti = kwargs['ti']
     ti.xcom_push(key='execution_date_kst', value=execution_date_kst)
 
-def extract_csv_from_gcs(execution_date_str, **kwargs):
-    ti = kwargs['ti']
+def formatted_days(ti):
+    # XCom을 사용하여 execution_date_kst를 가져옴
     execution_date_kst = ti.xcom_pull(task_ids='set_kst_execution_date', key='execution_date_kst')
     # Convert the pulled execution_date_kst string back to a datetime object
     execution_date_kst_dt = datetime.strptime(execution_date_kst, '%Y-%m-%d %H:%M:%S')
     formatted_day = execution_date_kst_dt.strftime("%d")
-    formatted_timestamp = execution_date_kst_dt.strftime("%Y%m%d%H")
+    formatted_hour = execution_date_kst_dt.strftime("%Y%m%d%H")
+    formatted_timestamp = execution_date_kst_dt.strftime("%Y%m%d%H%M")
+    return formatted_day, formatted_hour, formatted_timestamp
+
+def extract_csv_from_gcs(execution_date_str, **kwargs):
+    ti = kwargs['ti']
+    formatted_day, formatted_hour, formatted_timestamp = formatted_days(ti)
     gcs_hook = GCSHook(gcp_conn_id='google_cloud_GCS')
     bucket_name = 'pdc3project-landing-zone-bucket'
 
     # GCS 객체의 prefix와 정규 표현식 패턴을 설정
     prefix = f'source/source_parkinglot/INT_parking_data/2024/06/{formatted_day}'
-    regex_pattern = f'INT_parking_data_{formatted_timestamp}\d{{2}}.csv'
+    regex_pattern = f'INT_parking_data_{formatted_hour}\d{{2}}.csv'
 
     # 지정된 GCS prefix에서 모든 파일 리스트를 가져옴
     objects = gcs_hook.list(bucket_name, prefix=prefix)
@@ -52,6 +57,9 @@ def extract_csv_from_gcs(execution_date_str, **kwargs):
     object_name = matching_files[0]
     local_path = '/tmp/INT_parking_data.csv'
     gcs_hook.download(bucket_name, object_name, local_path)
+
+    # 다음 Task에 필요한 값을 XCom을 통해 전달
+    return {'formatted_day': formatted_day, 'formatted_timestamp': formatted_timestamp}
 
 
 def transform_csv_to_parquet(execution_date_str, **kwargs):
@@ -77,6 +85,7 @@ def upload_to_gcs(execution_date_str, **kwargs):
     execution_date_kst = ti.xcom_pull(task_ids='set_kst_execution_date', key='execution_date_kst')
     # Convert the pulled execution_date_kst string back to a datetime object
     execution_date_kst_dt = datetime.strptime(execution_date_kst, '%Y-%m-%d %H:%M:%S')
+    execution_date_kst_dt += timedelta(minutes=5)
     formatted_day = execution_date_kst_dt.strftime("%d")
     formatted_timestamp = execution_date_kst_dt.strftime("%Y%m%d%H%M")
     # 이전 태스크에서 저장된 Parquet 파일 경로를 XCom을 통해 가져옴
@@ -119,7 +128,8 @@ set_kst_task = PythonOperator(
 extract_task = PythonOperator(
     task_id='extract_csv_from_gcs',
     python_callable=extract_csv_from_gcs,
-    op_kwargs={'execution_date_str': '{{ ts }}'},  # ts는 실행 날짜와 시간을 문자열로 반환합니다.
+    op_kwargs={'execution_date_str': '{{ ts }}'},
+    provide_context=True,
     dag=dag,
 )
 
@@ -127,6 +137,7 @@ transform_task = PythonOperator(
     task_id='transform_csv_to_parquet',
     python_callable=transform_csv_to_parquet,
     op_kwargs={'execution_date_str': '{{ ts }}'},
+    provide_context=True,
     dag=dag,
 )
 
@@ -134,7 +145,42 @@ upload_task = PythonOperator(
     task_id='upload_to_gcs',
     python_callable=upload_to_gcs,
     op_kwargs={'execution_date_str': '{{ ts }}'},
+    provide_context=True,
     dag=dag,
 )
 
-set_kst_task >> extract_task >> transform_task >> upload_task
+airport = 'INT'
+bq_tasks = []
+tz = pytz.timezone('Asia/Seoul')
+now = datetime.now(tz)
+
+formatted_day = now.strftime("%d")
+rounded_minute = now.minute - (now.minute % 5)
+rounded_time = now.replace(minute=rounded_minute, second=0, microsecond=0)
+formatted_timestamp = rounded_time.strftime("%Y%m%d%H%M")
+source_object=[f'source/source_parkinglot/INT_parking_data/2024/06/{formatted_day}/INT_parking_data_{formatted_timestamp}.parquet']
+
+# GCSToBigQueryOperator에 대한 설정
+load_to_bigquery_task = GCSToBigQueryOperator(
+    task_id=f'load_{airport}_to_bigquery',
+    bucket='pdc3project-stage-layer-bucket',
+    source_objects=source_object,
+    destination_project_dataset_table=f'pdc3project.raw_data.parking_data_{airport}',
+    source_format='PARQUET',
+    write_disposition='WRITE_APPEND',
+    schema_fields=[
+        {'name': 'airportKor', 'type': 'STRING', 'mode': 'NULLABLE'},
+        {'name': 'parkingAirportCodeName', 'type': 'STRING', 'mode': 'NULLABLE'},
+        {'name': 'parkingCongestion', 'type': 'STRING', 'mode': 'NULLABLE'},
+        {'name': 'parkingCongestionDegree', 'type': 'STRING', 'mode': 'NULLABLE'},
+        {'name': 'parkingOccupiedSpace', 'type': 'INTEGER', 'mode': 'NULLABLE'},  # INT64 호환을 위해 INTEGER로 변경
+        {'name': 'parkingTotalSpace','type': 'INTEGER', 'mode': 'NULLABLE'},
+        {'name': 'datetm', 'type': 'INTEGER', 'mode': 'NULLABLE'},
+    ],
+    gcp_conn_id='google_cloud_bigquery',
+    dag=dag,
+)
+
+bq_tasks.append(load_to_bigquery_task)
+
+extract_task >> transform_task >> upload_task >> bq_tasks

--- a/dags/Parking_INT_ELT.py
+++ b/dags/Parking_INT_ELT.py
@@ -1,0 +1,140 @@
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from airflow.providers.google.cloud.hooks.gcs import GCSHook
+from airflow.providers.google.cloud.transfers.gcs_to_bigquery import GCSToBigQueryOperator
+from airflow.utils.dates import days_ago
+from datetime import datetime, timedelta
+import pyarrow.parquet as pq
+import pandas as pd
+import pyarrow as pa
+from plugins import slack
+import pytz
+import re
+
+
+def convert_to_kst(execution_date):
+    # UTC에서 한국 시간으로 변환
+    execution_date_utc = execution_date.replace(tzinfo=pytz.UTC)
+    execution_date_kst = execution_date_utc.astimezone(pytz.timezone('Asia/Seoul'))
+    return execution_date_kst.strftime('%Y-%m-%d %H:%M:%S')
+
+def set_kst_execution_date(**kwargs):
+    # Airflow의 execution_date를 가져와서 한국 시간대로 변환 후 XCom에 저장
+    execution_date = kwargs['execution_date']
+    execution_date_kst = convert_to_kst(execution_date)
+    ti = kwargs['ti']
+    ti.xcom_push(key='execution_date_kst', value=execution_date_kst)
+
+def extract_csv_from_gcs(execution_date_str, **kwargs):
+    ti = kwargs['ti']
+    execution_date_kst = ti.xcom_pull(task_ids='set_kst_execution_date', key='execution_date_kst')
+    # Convert the pulled execution_date_kst string back to a datetime object
+    execution_date_kst_dt = datetime.strptime(execution_date_kst, '%Y-%m-%d %H:%M:%S')
+    formatted_day = execution_date_kst_dt.strftime("%d")
+    formatted_timestamp = execution_date_kst_dt.strftime("%Y%m%d%H")
+    gcs_hook = GCSHook(gcp_conn_id='google_cloud_GCS')
+    bucket_name = 'pdc3project-landing-zone-bucket'
+
+    # GCS 객체의 prefix와 정규 표현식 패턴을 설정
+    prefix = f'source/source_parkinglot/INT_parking_data/2024/06/{formatted_day}'
+    regex_pattern = f'INT_parking_data_{formatted_timestamp}\d{{2}}.csv'
+
+    # 지정된 GCS prefix에서 모든 파일 리스트를 가져옴
+    objects = gcs_hook.list(bucket_name, prefix=prefix)
+
+    # 정규 표현식 패턴과 일치하는 파일을 찾음
+    matching_files = [obj for obj in objects if re.search(regex_pattern, obj)]
+
+    if not matching_files:
+        raise FileNotFoundError(f"No files matching pattern {regex_pattern} in {prefix}")
+
+    # 첫 번째로 일치하는 파일을 다운로드
+    object_name = matching_files[0]
+    local_path = '/tmp/INT_parking_data.csv'
+    gcs_hook.download(bucket_name, object_name, local_path)
+
+
+def transform_csv_to_parquet(execution_date_str, **kwargs):
+    # 로컬에 저장된 CSV 파일 경로를 설정
+    local_csv_path = '/tmp/INT_parking_data.csv'
+    df = pd.read_csv(local_csv_path)
+
+    # Parquet 파일로 저장할 경로를 설정
+    parquet_path = '/tmp/INT_parking_data.parquet'
+    table = pa.Table.from_pandas(df)
+    pq.write_table(table, parquet_path)
+
+    # 현재 태스크 인스턴스를 나타내는 task_instance 객체를 가져옴
+    ti = kwargs['ti']
+
+    # XCom을 사용하여 Parquet 파일 경로를 push(저장)
+    ti.xcom_push(key='parquet_path', value=parquet_path)
+
+
+def upload_to_gcs(execution_date_str, **kwargs):
+    # 현재 태스크 인스턴스를 나타내는 task_instance 객체를 가져옴
+    ti = kwargs['ti']
+    execution_date_kst = ti.xcom_pull(task_ids='set_kst_execution_date', key='execution_date_kst')
+    # Convert the pulled execution_date_kst string back to a datetime object
+    execution_date_kst_dt = datetime.strptime(execution_date_kst, '%Y-%m-%d %H:%M:%S')
+    formatted_day = execution_date_kst_dt.strftime("%d")
+    formatted_timestamp = execution_date_kst_dt.strftime("%Y%m%d%H%M")
+    # 이전 태스크에서 저장된 Parquet 파일 경로를 XCom을 통해 가져옴
+    parquet_path = ti.xcom_pull(key='parquet_path', task_ids='transform_csv_to_parquet')
+
+    # execution_date_str을 datetime 객체로 변환
+    execution_date = datetime.strptime(execution_date_str, '%Y-%m-%dT%H:%M:%S%z')
+    bucket = 'pdc3project-stage-layer-bucket'
+    gcs_hook = GCSHook(gcp_conn_id='google_cloud_GCS')
+    dst_path = f'source/source_parkinglot/INT_parking_data/2024/06/{formatted_day}/INT_parking_data_{formatted_timestamp}.parquet'
+
+    # Parquet 파일을 GCS에 업로드
+    gcs_hook.upload(bucket_name=bucket, object_name=dst_path, filename=parquet_path)
+
+
+default_args = {
+    'owner': 'airflow',
+    'start_date': days_ago(1),
+    'retries': 1,
+    'retry_delay': timedelta(minutes=1),
+    'on_failure_callback': slack.on_failure_callback,
+}
+
+dag = DAG(
+    'INT_csv_to_parquet',
+    default_args=default_args,
+    description='CSV 데이터를 Parquet으로 변환하여 GCS에 저장하는 DAG',
+    schedule_interval='*/5 * * * *',
+    max_active_runs=1,
+    catchup=False,
+)
+
+set_kst_task = PythonOperator(
+    task_id='set_kst_execution_date',
+    python_callable=set_kst_execution_date,
+    provide_context=True,
+    dag=dag,
+)
+
+extract_task = PythonOperator(
+    task_id='extract_csv_from_gcs',
+    python_callable=extract_csv_from_gcs,
+    op_kwargs={'execution_date_str': '{{ ts }}'},  # ts는 실행 날짜와 시간을 문자열로 반환합니다.
+    dag=dag,
+)
+
+transform_task = PythonOperator(
+    task_id='transform_csv_to_parquet',
+    python_callable=transform_csv_to_parquet,
+    op_kwargs={'execution_date_str': '{{ ts }}'},
+    dag=dag,
+)
+
+upload_task = PythonOperator(
+    task_id='upload_to_gcs',
+    python_callable=upload_to_gcs,
+    op_kwargs={'execution_date_str': '{{ ts }}'},
+    dag=dag,
+)
+
+set_kst_task >> extract_task >> transform_task >> upload_task

--- a/dags/Parking_INT_ELT.py
+++ b/dags/Parking_INT_ELT.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 import pyarrow.parquet as pq
 import pandas as pd
 import pyarrow as pa
+from plugins import slack
 import pytz
 import re
 
@@ -110,7 +111,7 @@ default_args = {
 }
 
 dag = DAG(
-    'INT_csv_to_parquet',
+    'BQ_INT_csv_to_parquet',
     default_args=default_args,
     description='CSV 데이터를 Parquet으로 변환하여 GCS에 저장하는 DAG',
     schedule_interval='*/5 * * * *',
@@ -172,7 +173,7 @@ load_to_bigquery_task = GCSToBigQueryOperator(
         {'name': 'airportKor', 'type': 'STRING', 'mode': 'NULLABLE'},
         {'name': 'parkingAirportCodeName', 'type': 'STRING', 'mode': 'NULLABLE'},
         {'name': 'parkingCongestion', 'type': 'STRING', 'mode': 'NULLABLE'},
-        {'name': 'parkingCongestionDegree', 'type': 'STRING', 'mode': 'NULLABLE'},
+        {'name': 'parkingCongestionDegree', 'type': 'INTEGER', 'mode': 'NULLABLE'},
         {'name': 'parkingOccupiedSpace', 'type': 'INTEGER', 'mode': 'NULLABLE'},  # INT64 호환을 위해 INTEGER로 변경
         {'name': 'parkingTotalSpace','type': 'INTEGER', 'mode': 'NULLABLE'},
         {'name': 'datetm', 'type': 'INTEGER', 'mode': 'NULLABLE'},


### PR DESCRIPTION
Parking_CJU_ELT,Parking_INT_ELT,Parking_GMP_ELT

GCS landing -> Parquet 변환 -> GCS stage -> BigQuery raw_data 적재 확인
Preset에 적재되는 것도 확인 기존 {aircode}_Parking Dag들과 같이 5분마다 실행

preset의 경우 업데이트 1분마다 갱신

빅쿼리 테이블은 {aircode}_Parking Dag과 동일하게 구성

        {'name': 'airportKor', 'type': 'STRING', 'mode': 'NULLABLE'},
        {'name': 'parkingAirportCodeName', 'type': 'STRING', 'mode': 'NULLABLE'},
        {'name': 'parkingCongestion', 'type': 'STRING', 'mode': 'NULLABLE'},
        {'name': 'parkingCongestionDegree', 'type': 'INTEGER', 'mode': 'NULLABLE'},
        {'name': 'parkingOccupiedSpace', 'type': 'INTEGER', 'mode': 'NULLABLE'},  # INT64 호환을 위해 INTEGER로 변경
        {'name': 'parkingTotalSpace', 'type': 'INTEGER', 'mode': 'NULLABLE'},
        {'name': 'datetm', 'type': 'INTEGER', 'mode': 'NULLABLE'},
        
       